### PR TITLE
Add :장바구니 금액 계산 기능 완료,header에 authirization 추가

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -9,6 +9,7 @@ import Main from './pages/Main/Main';
 import List from './pages/List/List';
 import Detail from './pages/Detail/Detail';
 import Search from './pages/Search/Search';
+import Cart from './pages/Cart/Cart';
 
 import { ThemeProvider } from 'styled-components';
 import theme from './styles/theme';

--- a/src/pages/Cart/CartData.js
+++ b/src/pages/Cart/CartData.js
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { useState } from 'react';
 import { BsBagX, BsX } from 'react-icons/bs';
 
 function CartNoData() {
@@ -17,8 +18,14 @@ function CartNoData() {
   );
 }
 
-function CartData({ data, quantity, event }) {
+function CartData({ data, quantity, event, changeState }) {
   // console.log(data);
+  const [discountTotal, setDiscountTotal] = useState(
+    (data.products.price_before - data.products.price_after) * quantity
+  );
+  const [afterTotal, setAfterTotal] = useState(
+    data.products.price_after * quantity
+  );
 
   const deleteHandler = () => {
     event(data.products.id);
@@ -29,6 +36,10 @@ function CartData({ data, quantity, event }) {
       `http://localhost:8000/cart/${data.products.id}?setQuantity=${e.target.value}`,
       { method: 'PUT' }
     );
+    setDiscountTotal(
+      (data.products.price_before - data.products.price_after) * e.target.value
+    );
+    setAfterTotal(data.products.price_after * e.target.value);
   };
 
   const intoString = dataname => {
@@ -65,7 +76,10 @@ function CartData({ data, quantity, event }) {
       <td>
         <select
           defaultValue={quantity > 10 ? 10 : quantity}
-          onChange={changeQuantity}
+          onChange={e => {
+            changeQuantity(e);
+            changeState(e);
+          }}
         >
           <option value="1">1개</option>
           <option value="2">2개</option>
@@ -79,12 +93,8 @@ function CartData({ data, quantity, event }) {
           <option value="10">10개</option>
         </select>
       </td>
-      <Price>
-        {Number(data.products.price_before * quantity).toLocaleString()}원
-      </Price>
-      <Price>
-        {Number(data.products.price_after * quantity).toLocaleString()}원
-      </Price>
+      <Price>{intoString(discountTotal)}원</Price>
+      <Price>{intoString(afterTotal)}원</Price>
       <DeleteData onClick={deleteHandler}>
         <BsX size={22} />
         <span>삭제</span>

--- a/src/styles/Common.js
+++ b/src/styles/Common.js
@@ -14,7 +14,10 @@ table, caption, tbody, tfoot, thead, tr, th, td,
 article, aside, canvas, details, embed, 
 figure, figcaption, footer, header, hgroup, 
 menu, nav, output, ruby, section, summary,
-time, mark, audio, video , input {font-family: 'pretendard';}
+time, mark, audio, video , input {font-family:'Pretendard', -apple-system, BlinkMacSystemFont, system-ui, Roboto,
+'Helvetica Neue', 'Segoe UI', 'Apple SD Gothic Neo', 'Noto Sans KR',
+'Malgun Gothic', 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
+sans-serif;}
 `;
 
 export default Common;


### PR DESCRIPTION
## 최근 작업 주제 
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

## 구현 목표 
- 장바구니 자동 금액계산 기능

## 구현 사항 설명 
1.  카트 DB에서 데이터를 불러와 상품 컴포넌트 생성
- 상품이 없을 경우, 빈 컴포넌트 보여주기
- 데이터에 들어있는 상품 금액 수량에 맞춰 계산하기
- 헤더에 로컬스토리지에 저장한 userId를 가져와 authorization 값에 추가


## 성장 포인트 
- 장바구니 기능 흐름을 익혔습니다!
- 하위 컴포넌트의 입력값에 따라 상위 컴포넌트가 변하는 상황을 겪었습니다.

## 기타 질문 및 특이 사항
- 테이블 css에 문제가 있습니다.