### PR TITLE
Fix : 테이블이 부모 div를 뚫고 나오는 현상 수정

### DIFF
--- a/src/pages/Cart/Cart.js
+++ b/src/pages/Cart/Cart.js
@@ -34,7 +34,7 @@ function Cart() {
     })
       .then(res => res.json())
       .then(data => {
-        setCartList(data);
+        data.message === 'NEED_TO_LOGIN' ? setCartList([]) : setCartList(data);
       });
     const newTotalPrice = cartList
       .map(order => order.products.price_before * order.quantity)

--- a/src/pages/Cart/Cart.js
+++ b/src/pages/Cart/Cart.js
@@ -1,8 +1,7 @@
 import styled from 'styled-components';
 import { useState, useEffect } from 'react';
 import { CartNoData, CartData } from './CartData';
-
-import { BiLeftArrowAlt, BiMinus, BiPlus } from 'react-icons/bi';
+import { BiMinus, BiPlus } from 'react-icons/bi';
 
 function Cart() {
   const deliveryFee = 2500;
@@ -55,7 +54,6 @@ function Cart() {
     setTotalDiscountPrice(newDiscountPrice);
   }, [cartList, render]);
 
-  //console.log(cartList);
   return (
     <CartWrap>
       <CartHeader>
@@ -194,10 +192,7 @@ const H3 = styled.h3`
 const CartListTable = styled.table`
   display: table;
   table-layout: fixed;
-  & thead,
-  tbody {
-    display: table-row;
-  }
+  width: 100%;
 `;
 const CartListHead = styled.thead`
   border-top: 2px solid #333;
@@ -246,7 +241,7 @@ const PaymentArea = styled.tr`
     text-align: right;
     font-size: ${props => props.theme.fontSize.h5};
     & span {
-      margin: 0 0 0 5px;
+      margin: 0 0 0 10px;
       font-size: ${props => props.theme.fontSize.h2};
       color: ${props => props.theme.point};
       font-weight: 600;

--- a/src/pages/Signup/Signup.js
+++ b/src/pages/Signup/Signup.js
@@ -147,12 +147,13 @@ function Signup() {
           )}
           <Input
             type="password"
-            placeholder="비밀번호는 8자 이상으로 숫자와 문자를 최소 1자씩 포함해주세요."
+            placeholder="비밀번호는 8자 이상으로 숫자, 문자, 특수문자를 최소 1자씩 포함해주세요."
             aria-invalid={errors.password ? '#ff0000' : '#dadada'}
             disable="false"
             {...register('password', {
               required: true,
-              pattern: /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$/,
+              pattern:
+                /^(?=.*[A-Za-z])(?=.*\d)(?=.*[$@$!%*#?&])[A-Za-z\d$@$!%*#?&]{8,}$]/,
             })}
           />
           {errors.passwordCheck &&


### PR DESCRIPTION
## 최근 작업 주제 
- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

## 구현 목표 
- 테이블이 부모 요소를 뚫고 나오지 않도록 맞추는 것

## 구현 사항 설명 
1. table에 table-layout 요소 추가 후 width값을 100%로 지정해줌


## 성장 포인트 
- table과 산하 엘리먼트를 사용하여 표 스타일링 하는 법
- colgroup으로 width값을 지정해주면 나머지 td 및 th들이 그 width값을 따라갑니다!
- 
## 기타 질문 및 특이 사항
- 속시원