### PR TITLE
Fix : 상품 없을 시 테이블 레이아웃이 깨지던 문제 수정, 장바구니에 담은 아이템이 0개일 시 배송비 0원으로 변경

### DIFF
--- a/src/components/Nav/CartModal.js
+++ b/src/components/Nav/CartModal.js
@@ -17,7 +17,7 @@ function CartModal(props) {
     })
       .then(res => res.json())
       .then(data => {
-        setCartItem(data);
+        // setCartItem(data);
         console.log(data);
       });
   }, []);

--- a/src/pages/Cart/Cart.js
+++ b/src/pages/Cart/Cart.js
@@ -4,11 +4,11 @@ import { CartNoData, CartData } from './CartData';
 import { BiMinus, BiPlus } from 'react-icons/bi';
 
 function Cart() {
-  const deliveryFee = 2500;
   const [cartList, setCartList] = useState([]);
   const [totalBeforePrice, setTotalBeforePrice] = useState(0);
   const [totalDiscountPrice, setTotalDiscountPrice] = useState(0);
   const [render, setRender] = useState(false);
+  let deliveryFee = cartList.length === 0 ? 0 : 2500;
 
   const intoString = dataname => {
     return dataname.toString().replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, ',');
@@ -70,7 +70,7 @@ function Cart() {
         <CartListTable>
           <colgroup>
             <col width="50" />
-            <col width="*" />
+            <col width="440" />
             <col width="100" />
             <col width="100" />
             <col width="110" />
@@ -106,7 +106,7 @@ function Cart() {
             )}
 
             <TotalPriceArea>
-              <td colSpan="6">
+              <td colSpan="99">
                 <TotalPayList>
                   <PriceInfo>
                     총 상품금액
@@ -139,7 +139,7 @@ function Cart() {
               </td>
             </TotalPriceArea>
             <PaymentArea>
-              <td colSpan="6">
+              <td colSpan="99">
                 결제 예상 금액
                 <span>
                   {intoString(


### PR DESCRIPTION
## 최근 작업 주제 
- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

## 구현 목표 
- 장바구니에 담은 상품이 없을 시 테이블 헤더가 어그러지는 문제 수정
- 장바구니에 담은 상품이 없을 시 배송비가 0원으로 책정
## 구현 사항 설명 
1. 뵤

## 성장 포인트 
- 
## 기타 질문 및 특이 사항
- colgroup에 자동계산되도록 값 입력했는데 왜안될까요 어이가 없다